### PR TITLE
feat: add multi-architecture support (AMD64 + ARM64) with native runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,10 +153,12 @@ jobs:
   # -----------------------------------------------
   # Job: List All Image Sizes (from build artifacts)
   # -----------------------------------------------
+  # Only runs on main branch push when images are actually pushed to registry
   list-sizes:
     name: List Image Sizes
     runs-on: ubuntu-24.04
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Download all image size artifacts
@@ -172,18 +174,12 @@ jobs:
           echo "Docker Image Sizes for GitHub Packages"
           echo "========================================"
           echo ""
-          echo "Debug: Checking /tmp/sizes directory..."
-          ls -la /tmp/sizes/ 2>/dev/null || echo "Directory empty or not found"
-          echo ""
           echo "| Version | Base | Arch | Size | Digest |"
           echo "|---------|------|------|------|--------|"
 
           # Process each JSON file (find recursively)
           for file in $(find /tmp/sizes -name "*.json" 2>/dev/null); do
             if [ -f "$file" ]; then
-              echo "Debug: Processing $file"
-              cat "$file" 2>/dev/null || echo "Cannot read file"
-              echo ""
               VERSION=$(jq -r '.version' "$file")
               BASE=$(jq -r '.base' "$file")
               ARCH=$(jq -r '.arch' "$file")


### PR DESCRIPTION
## Summary

This PR adds multi-architecture Docker build support to the docker-php project:

1. **Build Matrix Expansion**: Added `arch` dimension (amd64, arm64) to the build matrix
2. **Native ARM64 Runners**: Uses `ubuntu-24.04-arm` runners for ARM64 builds instead of QEMU emulation (3-4x faster)
3. **Dynamic Platform Targeting**: Each build targets its specific architecture (`linux/${{ matrix.arch }}`)
4. **Manifest List Creation**: New `create-manifests` job combines AMD64 and ARM64 images into unified multi-arch manifests
5. **Updated Reporting**: Image size listings now include architecture column
6. **Security Scan Update**: Scans the multi-arch manifest instead of architecture-specific tags

## Benefits

- **True Multi-Arch Images**: Users can now pull `ghcr.io/juniyadi/php-base:8.5` and get the correct architecture for their machine (AMD64 or ARM64)
- **Faster ARM64 Builds**: Native ARM64 runners eliminate QEMU overhead (previously ~15 min, now ~3-4 min per arch)
- **Simplified Tagging**: No more `-amd64` or `-arm64` suffixes on standard tags

## Tag Structure

| Tag | Points To |
|-----|-----------|
| `8.5-alpine` | Multi-arch manifest (AMD64 + ARM64) |
| `8.5-debian` | Multi-arch manifest (AMD64 + ARM64) |
| `8.4-alpine` | Multi-arch manifest (AMD64 + ARM64) |
| `8.3-alpine` | Multi-arch manifest (AMD64 + ARM64) |
| `8.2-alpine` | Multi-arch manifest (AMD64 + ARM64) |
| `latest` | Points to 8.5-alpine multi-arch |
| `alpine` | Points to 8.5-alpine multi-arch |

Architecture-specific tags still exist for debugging:
- `8.5-alpine-amd64`, `8.5-alpine-arm64`
- `8.5-debian-amd64`, `8.5-debian-arm64`
- etc.

## Build Time

Estimated total build time increases from ~5 min to ~8 min:
- AMD64 builds: ~3 min (unchanged)
- ARM64 builds: ~3 min (native runners, much faster than QEMU)
- Manifest creation: ~2 min

## How to Pull

```bash
# Works on ALL machines - automatically pulls correct architecture
docker pull ghcr.io/juniyadi/php-base:8.5
docker pull ghcr.io/juniyadi/php-base:alpine
docker pull ghcr.io/juniyadi/php-base:latest
```

## Files Changed

- `.github/workflows/build.yml` - 106 insertions, 23 deletions