### PR TITLE
fix: add OCI image description annotation to manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,6 +267,7 @@ jobs:
 
               # Create multi-arch manifest (combines AMD64 + ARM64)
               docker buildx imagetools create \
+                --annotation "org.opencontainers.image.description=Multi-version PHP ${VERSION} runtime with ${BASE} base" \
                 ${REGISTRY}/${IMAGE_NAME}:${VERSION}-${BASE}-amd64 \
                 ${REGISTRY}/${IMAGE_NAME}:${VERSION}-${BASE}-arm64 \
                 -t ${REGISTRY}/${IMAGE_NAME}:${VERSION}-${BASE}
@@ -276,6 +277,7 @@ jobs:
           # Create version-only tag (defaults to 8.5-debian multi-arch)
           echo "Creating version-only tags..."
           docker buildx imagetools create \
+            --annotation "org.opencontainers.image.description=Multi-version PHP 8.5 runtime with debian base" \
             ${REGISTRY}/${IMAGE_NAME}:8.5-debian-amd64 \
             ${REGISTRY}/${IMAGE_NAME}:8.5-debian-arm64 \
             -t ${REGISTRY}/${IMAGE_NAME}:8.5
@@ -283,6 +285,7 @@ jobs:
           # Create latest tag from 8.5-debian (glibc compatibility)
           echo "Creating latest tag..."
           docker buildx imagetools create \
+            --annotation "org.opencontainers.image.description=Multi-version PHP runtime with debian base" \
             ${REGISTRY}/${IMAGE_NAME}:8.5-debian-amd64 \
             ${REGISTRY}/${IMAGE_NAME}:8.5-debian-arm64 \
             -t ${REGISTRY}/${IMAGE_NAME}:latest


### PR DESCRIPTION
## Summary

Add `org.opencontainers.image.description` annotation to multi-arch manifest creation commands in the CI workflow.

## Problem

Docker build produces warnings about missing manifest-level description annotation for multi-arch images. The OCI image spec requires the description at the manifest level, not just in individual image configs.

## Solution

Add `--annotation "org.opencontainers.image.description=..."` flags to all `docker buildx imagetools create` commands:

1. Version-base manifests (e.g., `8.5-alpine`, `8.5-debian`) - using shell variables
2. Version-only tag (`8.5`) - hardcoded for debian base
3. Latest tag (`latest`) - hardcoded for debian base

## Verification

After merging, the CI run will produce manifests with the description annotation:

```bash
docker manifest inspect ghcr.io/juniyadi/php-base:8.5 | jq '.[0].annotations'
```