### PR TITLE
feat: optimize extension installation (avoid duplicates)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ RUN docker-php-ext-configure gd \
         --with-jpeg
 
 # Install core extensions (includes curl for Laravel HTTP client)
+# Note: pdo, mbstring, xml are already available in PHP base images
 RUN docker-php-ext-install -j$(nproc) \
-        pdo \
         pdo_mysql \
         pdo_pgsql \
         pdo_sqlite \
@@ -74,17 +74,14 @@ RUN docker-php-ext-install -j$(nproc) \
         curl
 
 RUN docker-php-ext-install -j$(nproc) \
-        mbstring \
         gd \
         intl \
         zip \
         bcmath
 
-# Install core extensions individually to isolate build issues
+# Install remaining extensions
 # Note: json, fileinfo, tokenizer are built into PHP 8.x core
 RUN docker-php-ext-install sockets
-RUN docker-php-ext-install xml
-RUN docker-php-ext-install xmlwriter
 
 # Install build dependencies for PECL extensions
 RUN if [ "${BASE_IMAGE}" = "debian" ]; then \


### PR DESCRIPTION
## Summary

Remove PHP extensions that are already available in official PHP base images to optimize build time and image size.

## Extensions Removed

These extensions are **already included** in PHP-FPM base images (Docker Hub official images):

| Extension | Reason |
|-----------|--------|
| `pdo` | Built into PHP base |
| `mbstring` | Built into PHP base |
| `xml` | Built into PHP base |
| `xmlwriter` | Part of xml extension |

## Verification

All removed extensions are still available and working:

```bash
$ php -m | grep -E "pdo|mbstring|xml"
mbstring
PDO
xml
xmlreader
xmlwriter
```

## Benefits

1. **Faster builds** - Fewer extensions to compile
2. **Smaller image** - No redundant extension code
3. **Cleaner Dockerfile** - Only install what's truly needed

## Reference

Based on analysis in pfnapp/Jenkins/builds/php/lists.md

## Checklist

- [x] Extensions identified as duplicates
- [x] Build tested on Alpine
- [x] Extensions verified available in container
- [x] No functionality loss

Closes #6